### PR TITLE
Fix padding on tvOS 18

### DIFF
--- a/RoonDisplay/ViewController.m
+++ b/RoonDisplay/ViewController.m
@@ -48,10 +48,6 @@
     [self.view setNeedsLayout];
     [self.view layoutIfNeeded];
 
-    //correct the offset
-    CGPoint point = CGPointMake(60, 90);
-    scrollView.contentInset = UIEdgeInsetsMake(-point.x, -point.y, -point.x, -point.y);
-
     scrollView.bounces = YES;
     scrollView.panGestureRecognizer.allowedTouchTypes = @[ @(UITouchTypeIndirect) ];
     scrollView.scrollEnabled = NO;


### PR DESCRIPTION
Before these changes, I see improper padding in the webview on tvOS 18.3:

![Image](https://github.com/user-attachments/assets/bcb4e3db-e061-490e-ae5c-03049af2fbd9)

Removing the offset correction fixes this:

![Screenshot 2025-04-19 at 4 27 15 PM](https://github.com/user-attachments/assets/5256b90d-40a8-43f6-bfb2-251ca485e675)
